### PR TITLE
chore: bump urllib3 from 1.26.17 to 1.26.18 in /synthtool/gcp/templat…

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -13,5 +13,5 @@
 # limitations under the License.
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-java:latest
-  digest: sha256:d0a8eb7ffc63ddce4c63191373d6e99d5385516423c396de207dedf2b6db7427
-# created: 2023-10-17T17:33:29.360983119Z
+  digest: sha256:4875b2142cb4325542ba4f3175a81921c4b2b8256db012b220e3ca9637b34154
+# created: 2023-10-24T01:51:42.863726766Z

--- a/.kokoro/requirements.txt
+++ b/.kokoro/requirements.txt
@@ -470,9 +470,9 @@ typing-extensions==4.7.1 \
     --hash=sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36 \
     --hash=sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2
     # via -r requirements.in
-urllib3==1.26.17 \
-    --hash=sha256:24d6a242c28d29af46c3fae832c36db3bbebcc533dd1bb549172cd739c82df21 \
-    --hash=sha256:94a757d178c9be92ef5539b8840d48dc9cf1b2709c9d6b588232a055c524458b
+urllib3==1.26.18 \
+    --hash=sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07 \
+    --hash=sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0
     # via
     #   google-auth
     #   requests


### PR DESCRIPTION
…es/java_library/.kokoro (#1885)

Source-Link: https://github.com/googleapis/synthtool/commit/e4a9d44f7d1ddda567c14bce7df4d93fdb010de0
Post-Processor: gcr.io/cloud-devrel-public-resources/owlbot-java:latest@sha256:4875b2142cb4325542ba4f3175a81921c4b2b8256db012b220e3ca9637b34154

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-api-java-client/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
